### PR TITLE
test with sleep are inconscient

### DIFF
--- a/test/ralitobu_sleep_test.exs
+++ b/test/ralitobu_sleep_test.exs
@@ -1,0 +1,26 @@
+defmodule RalitobuSleepTest do
+  use ExUnit.Case
+
+  test "test basic" do
+    {res, _, _, _, _, _, _} = Ralitobu.checkout("my-bucket", 3, 10_000)
+    assert res == :ok
+  end
+
+  test "ralitobu test with sleep" do
+    # run 100 checkout
+    _res = for _i <- 1..100 do
+      Ralitobu.checkout("bucket-test-spawn", 10_000, 750)
+    end
+
+    # Sleep for 0.5 second, could also use (Process.sleep(500))
+    :timer.sleep(500)
+
+    # inspect the bucket
+    {_res, count, count_remaining, _, _, _, _} = Ralitobu.inspect("bucket-test-spawn", 10_000, 750)
+
+    assert count == 100
+    assert count_remaining == 9900
+  end
+
+end
+


### PR DESCRIPTION
Hi,

This PR is to add a test that outline a strange behavior.
If we put a `sleep` between the calls to `checkout` and `inspect` the test result are inconsistent. 
If you run those tests several times, it will sometime pass and sometime not.
Any clue will be appreciated.

➜  ralitobu git:(master) ✗ MIX_ENV=test mix test
  1) test ralitobu test with sleep (RalitobuSleepTest)
     test/ralitobu_sleep_test.exs:9
     Assertion with == failed
     code:  assert count == 100
     left:  0
     right: 100
     stacktrace:
       test/ralitobu_sleep_test.exs:21: (test)
Finished in 0.5 seconds
**3 tests, 1 failure**


➜  ralitobu git:(master) ✗ MIX_ENV=test mix test
Finished in 0.5 seconds
**3 tests, 0 failures**
